### PR TITLE
FIX: constructor cannot be final due to how doctrine orm cache works

### DIFF
--- a/src/Entity/FeatureFlag.php
+++ b/src/Entity/FeatureFlag.php
@@ -56,7 +56,7 @@ abstract class FeatureFlag implements GenericEntityInterface {
   /**
    * Use setters or createFromConsole to build instance.
    */
-  public final function __construct() {
+  public function __construct() {
   }
 
   /**


### PR DESCRIPTION
Avoid `NOTICE: PHP message: PHP Fatal error:  Cannot override final method HalloVerden\FeatureFlagBundle\Entity\FeatureFlag::__construct() in /var/www/app/var/cache/build/doctrine/orm/Proxies`